### PR TITLE
Update Access statistics Js Address &Fix Gitment Error

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -1,4 +1,4 @@
-<script async src="//dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js"></script>
+<script async src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
 <script src="//cdn.bootcss.com/jquery/3.2.1/jquery.min.js"></script>
 <script>
   var mihoConfig = {

--- a/layout/_partial/plugins/comments/gitment.ejs
+++ b/layout/_partial/plugins/comments/gitment.ejs
@@ -1,13 +1,15 @@
     <link rel="stylesheet" href="//unpkg.com/gitment/style/default.css">
     <script src="//unpkg.com/gitment/dist/gitment.browser.js"></script>
-    <script>
-        var gitment = new Gitment({
-            owner: '<%- theme.gitment.owner %>',
-            repo: '<%- theme.gitment.repo %>',
-            oauth: {
-                client_id: '<%- theme.gitment.client_id %>',
-                client_secret: '<%- theme.gitment.client_secret %>',
-            },
-        })
-        gitment.render('comments')
-    </script>
+    <div id="comments">
+        <script>
+            var gitment = new Gitment({
+                owner: '<%- theme.gitment.owner %>',
+                repo: '<%- theme.gitment.repo %>',
+                oauth: {
+                    client_id: '<%- theme.gitment.client_id %>',
+                    client_secret: '<%- theme.gitment.client_secret %>',
+                },
+            })
+            gitment.render('comments')
+        </script>
+    </div>


### PR DESCRIPTION
>Update Access statistics Js Address

“不蒜子”访问量统计地址已经迁移：busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js

>关于Gitment的问题

 #24  中报错修复：添加一个div id为comments

> Gitment还有2个无法正常的问题（未修复），更改法见下面：

miho/layout/_partial/plugins/comments/gitment.ejs中gitment.browser.js地址更改为
`    <script src="//jjeejj.github.io/js/gitment.js"></script>
`
gitment配置owner前添加
`id: '<%= page.title %>',`

> 不更改js地址则会出现`[object ProgressEvent]`错误，因为gitment作者提供的CORS header 的服务已经停了，参考[https://github.com/imsun/gitment/issues/170](gitment#170) ，所以更改为别人提供的js就可以正常使用。

> gitment的id默认使用链接，会超过50字符，会报错`Error: Validation Failed`，改成标题就好了。